### PR TITLE
Pass the query to `wmic` directly as arguments

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -26,9 +26,16 @@ async function getChromeMajorVersion(): Promise<{chromeVersion: string, chromeMa
 
     if (installations && installations.length > 0) {
       if (platform === 'win32') {
-        const source = spawn('wmic');
-        source.stdin.end(
-          `datafile where "name='${installations[0].replace(/\\/g, '\\\\')}'" get version /value`
+        const source = spawn(
+          'wmic',
+          [
+            'datafile',
+            'where',
+            `name='${installations[0].replace(/\\/g, '\\\\')}'`,
+            'get',
+            'version',
+            '/value'
+          ]
         );
 
         source.stdout.on('exit', () => reject('Unable to get Chrome version from wmic (exit)'));


### PR DESCRIPTION
Changed the `spawn` to have the `wmic` query as arguments instead of feeding it into the `stdin`.